### PR TITLE
Moved Dockerfiles to examples/dockerfiles (#946)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ way to install it is via `pip`:
 pip install --upgrade mxnet==1.6 gluonts
 ```
 
+## Dockerfiles
+
+Dockerfiles compatible with Amazon Sagemaker can be found in the [examples/dockerfiles](https://github.com/awslabs/gluon-ts/tree/master/examples/dockerfiles) folder.
+
 ## Quick start guide
 
 This simple example illustrates how to train a model from GluonTS on some data,

--- a/examples/dockerfiles/Dockerfile
+++ b/examples/dockerfiles/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.7
 
 ADD . /gluonts
 
+RUN pip install -r /gluonts/requirements/requirements-mxnet.txt
 RUN pip install /gluonts[shell]
 
 ENTRYPOINT ["python", "-m", "gluonts.shell"]

--- a/examples/dockerfiles/Dockerfile.gpu
+++ b/examples/dockerfiles/Dockerfile.gpu
@@ -2,8 +2,8 @@ FROM nvidia/cuda:9.2-cudnn7-runtime-ubuntu18.04
 
 RUN apt-get update --fix-missing && \
     apt-get install -y --no-install-recommends \
-        wget bzip2 ca-certificates curl git build-essential \
-        cmake python3.7 python3.7-dev python3.7-distutils pkg-config && \
+    wget bzip2 ca-certificates curl git build-essential \
+    cmake python3.7 python3.7-dev python3.7-distutils pkg-config && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.7 get-pip.py
@@ -14,6 +14,7 @@ RUN echo '#!/bin/bash\necho Building container with GPU support' > /usr/bin/nvid
 
 ADD . /gluonts
 
+RUN pip3.7 install mxnet-cu92>=1.6.0
 RUN pip3.7 install /gluonts[shell]
 
 ENTRYPOINT ["python3.7", "-m", "gluonts.shell"]

--- a/examples/dockerfiles/Dockerfile.r
+++ b/examples/dockerfiles/Dockerfile.r
@@ -1,6 +1,9 @@
 FROM rpy2/rpy2:2.9.x
 
-RUN pip3 install --upgrade mxnet==1.6 "gluonts[shell]"
+ADD . /gluonts
+
+RUN pip install -r /gluonts/requirements/requirements-mxnet.txt
+RUN pip install /gluonts[shell]
 
 RUN R -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")'
 

--- a/examples/dockerfiles/README.md
+++ b/examples/dockerfiles/README.md
@@ -1,0 +1,26 @@
+# Instructions for using the Dockerfiles
+
+To build these dockerfiles go to the Gluon-TS root directory and enter this command:
+
+```bash 
+docker build . -f examples/dockerfiles/<dockerfile>
+```
+
+Or alternatively in the current directory:
+
+```bash
+docker build ../.. -f <dockerfile>
+```
+
+The built images are compatible with sagemaker.
+For more information about the shell and the available params, see the [shell documentation](https://github.com/awslabs/gluon-ts/tree/master/src/gluonts/shell).
+
+
+## How to choose between the dockerfiles
+
+* Dockerfile
+    - Gluon-TS models using CPU.
+* Dockerfile.gpu
+    -  Gluon-TS models on a GPU accelerated machine. 
+* Dockerfile.r
+    - This provides dependencies for models defined in [gluonts.model.r_forecast](https://gluon-ts.mxnet.io/api/gluonts/gluonts.model.r_forecast.html).


### PR DESCRIPTION
* Added MXnet install into dockerfiles

* Update Dockerfile

Adding jaspers suggestion

Co-authored-by: Jasper <jasper.b.schulz@googlemail.com>

* Dockerfile.gpu now uses same mxnet version as in requirements.txt

* Added support for RForecastPredictor

Tested this using the `ets` method and the new experimentation framework.

* Moved dockefiles to examples folder + updated readme

* Added readme, reverted the addition of R to the Dockerfile

* Updated based on Jaspers suggestions

* Update examples/dockerfiles/README.md

Co-authored-by: Jasper <jasper.b.schulz@googlemail.com>

* Update examples/dockerfiles/README.md

Co-authored-by: Jasper <jasper.b.schulz@googlemail.com>

* Update examples/dockerfiles/README.md

Co-authored-by: Jasper <jasper.b.schulz@googlemail.com>

* cleanup from last commits on github

Co-authored-by: Jasper <jasper.b.schulz@googlemail.com>
Co-authored-by: Jasper <schjaspe@amazon.de>
Co-authored-by: Aaron Spieler <25365592+AaronSpieler@users.noreply.github.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
